### PR TITLE
Update 11ty to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/juanfernandes/eleventy-plugin-cloudinary#readme",
   "dependencies": {
-    "@11ty/eleventy": "^0.5.2"
+    "@11ty/eleventy": "^1.0.0"
   }
 }


### PR DESCRIPTION
The previous semver lock in package.json prevented v1 releases of eleventy being loaded by the plugin.